### PR TITLE
Variable "iac_lic_content" defined but not used in asg module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ module "irisanywhere1" {
   ia_cert_file        = ""
   ia_cert_key_content = ""
   ia_customer_id      = "customerID"
-  ia_lic_content      = ""
   ia_max_sessions     = "2"
   ia_s3_conn_id       = "licenced-email@domain.com"
   ia_s3_conn_code     = "licensecode"

--- a/asg/asg.tf
+++ b/asg/asg.tf
@@ -58,7 +58,6 @@ data "template_file" "cloud_init" {
     cooldown              = var.asg_scalein_cooldown
     ia_adm_id             = var.ia_adm_id
     ia_adm_pw             = var.ia_adm_pw
-    ia_lic_content        = var.ia_lic_content
     ia_cert_file          = var.ia_cert_file
     ia_cert_key_content   = var.ia_cert_key_content
     ia_max_sessions       = var.ia_max_sessions

--- a/asg/cloud_init.ps1
+++ b/asg/cloud_init.ps1
@@ -3,8 +3,6 @@ Write-Output "TIMING: Cloud_init start at $(Get-Date)"
 
 $iadmid = "${ia_adm_id}"
 $iadmpw = "${ia_adm_pw}"
-$liccontent = "${ia_lic_content}"
-$liccontent = "${ia_lic_content}"
 $certfile = "${ia_cert_file}"
 $certkeycontent = "${ia_cert_key_content}"
 $S3ConnID = "${ia_s3_conn_id}"

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -168,11 +168,6 @@ variable "ia_cert_key_content" {
   default     = ""
 }
 
-variable "ia_lic_content" {
-  type        = string
-  description = "IA license file data"
-}
-
 variable "ia_s3_conn_id" {
   type        = string
   description = "S3 Connector SaaS license UID"


### PR DESCRIPTION
The variable "iac_lic_content" was defined for use in the asg module, but was never actually used.

This pull request achieves the following:

- Removes the unused references to iac_lic_content in the cloud-init powershell template (cloud_init.ps1).
- Removes the unused references to iac_lic_content in the template_file  data block used to customize the cloud-init powershell script (asg.tf).
- Removes the iac_lic_content variable declaration block (variables.tf).
- Updates the example code block in the repo's README to remove references to iac_lic_content.