### PR TITLE
Extend Iris asg module to allow for configuring ALB in internal mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ module "irisanywhere1" {
 
   access_cidr = ["0.0.0.0/0"]
 
+  alb_internal = true
+
   lb_check_interval      = 30
   lb_unhealthy_threshold = 2
 
@@ -127,6 +129,7 @@ module "irisanywhere1" {
 ### Argument Reference:
 The following arguments are supported:
 * `access_cidr` - (Optional) List of network cidr that have access.  Default to `["0.0.0.0/0"]`
+* `alb_internal` - (Optional) sets the application load balancer for Iris Anywhere to internal mode.  Default to `false`
 * `asg_check_interval` - (Optional) Autoscale check interval.  Default to `60` (seconds)
 * `asg_scalein_cooldown` - (Optional) Scale in cooldown period.  Default to `300` (seconds)
 * `asg_scalein_evaluation` - (Optional) Scale in evaluation periods.  Default to `2` (evaluation periods)

--- a/asg/loadbalancer.tf
+++ b/asg/loadbalancer.tf
@@ -1,6 +1,6 @@
 resource "aws_lb" "iris_alb" {
   name_prefix                = substr(replace("${var.hostname_prefix}-${var.instance_type}-alb", ".", ""), 0, 6)
-  internal                   = false
+  internal                   = var.alb_internal
   security_groups            = [aws_security_group.alb.id]
   subnets                    = var.subnet_id
   enable_deletion_protection = false

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -4,6 +4,12 @@ variable "access_cidr" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "alb_internal" {
+  type        = bool
+  description = "(Optional) sets the application load balancer for Iris Anywhere to internal mode.  Default to `false`"
+  default     = false
+}
+
 variable "asg_check_interval" {
   type        = number
   description = "(Optional) Autoscale check interval.  Default to `60`"


### PR DESCRIPTION
The ALB module for the IA servers within the asg module were hardcoded to be deployed in public subnets.  Added a variable `alb_internal` that allows the user to deploy the ALB to internal subnets.  This variable is defaulted to false to retain the initial functionality of the module unless specifically overridden.