### PR TITLE
ASG: EC2 public IP allocation change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ module "irisanywhere1" {
 ### Argument Reference:
 The following arguments are supported:
 * `access_cidr` - (Optional) List of network cidr that have access.  Default to `["0.0.0.0/0"]`
-* `alb_internal` - (Optional) sets the application load balancer for Iris Anywhere to internal mode.  Default to `false`
+* `alb_internal` - (Optional) sets the application load balancer for Iris Anywhere to internal mode.  When set to `true` this also disables allocating public IP addresses to Iris Anywhere EC2 instances. Default to `false`
 * `asg_check_interval` - (Optional) Autoscale check interval.  Default to `60` (seconds)
 * `asg_scalein_cooldown` - (Optional) Scale in cooldown period.  Default to `300` (seconds)
 * `asg_scalein_evaluation` - (Optional) Scale in evaluation periods.  Default to `2` (evaluation periods)

--- a/asg/asg.tf
+++ b/asg/asg.tf
@@ -100,7 +100,7 @@ resource "aws_launch_template" "iris" {
   }
 
   network_interfaces {
-    associate_public_ip_address = true
+    associate_public_ip_address = var.alb_internal ? false : true
     security_groups             = [aws_security_group.iris.id]
   }
 


### PR DESCRIPTION
Changes made to control public IP allocation of EC2 instances.  When the ALB is set to internal mode (using alb_internal variable set to true), we do not allocate a public IP address to the EC2 instances.